### PR TITLE
Removed last assignement point from "Sess2"

### DIFF
--- a/sess2/index.php
+++ b/sess2/index.php
@@ -39,7 +39,6 @@
                 <li>pane käima ka "Kalkulaatorite parameetrid" ja lahenda seal all olevad ülesanded,</li>
                 <li>jätka "Andmete talletamine objektis" + sealsed ülesanded,</li>
                 <li>kui jääb aega, siis uuri materjalides järgnevana tulevat "Objekti graafilist väljundit" ja sealseid ülesandeid.</li>
-                <li>Tee Fork ja oma esimene pull request</li>
             </ol>
         </div>
     </div>


### PR DESCRIPTION
Removed last assignement point from "sess2" because it was added during the presentation in class. It was not meant as an actual assignement. : )